### PR TITLE
fix(blog): resolve timezone offset on dates and image aspect ratio squishing

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -19,7 +19,8 @@ const { Content } = await render(post);
 
 // Format date
 const formattedDate = post.data.date 
-  ? new Date(post.data.date).toLocaleDateString('en-US', {
+  ? post.data.date.toLocaleDateString('en-US', {
+      timeZone: 'UTC',
       year: 'numeric',
       month: 'long',
       day: 'numeric'
@@ -148,6 +149,8 @@ const formattedDate = post.data.date
   
   .markdown-body img {
     max-width: 100%;
+    width: 100% !important;
+    height: auto !important;
     border-radius: var(--radius-sm);
     margin: 1.5rem 0;
     border: 1px solid var(--border-color);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -40,7 +40,8 @@ const cleanSlug = (id: string) => id.replace('/index.md', '').replace('index.md'
       <div class="blog-grid">
         {sortedPosts.map(post => {
           const dateString = post.data.date 
-            ? new Date(post.data.date).toLocaleDateString('en-US', {
+            ? post.data.date.toLocaleDateString('en-US', {
+                timeZone: 'UTC',
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric'


### PR DESCRIPTION
Fixes timezone-based date shifts on the blog index and slug pages (forcing UTC date string resolution), and applies a css override of width: 100% !important and height: auto !important on markdown images to prevent aspect ratio squishing.